### PR TITLE
fix: correct docker-compose.yml indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,21 +18,21 @@
 #   ADVBBS_TCP_PORT      - TCP port if using tcp connection (default: 4403)
 
 services:
-    advbbs:
-        image: ghcr.io/zvx-echo6/advbbs:latest
-        container_name: advbbs
-        ports:
-          - "7681:7681"
-        volumes:
-          - ./data:/data
-        restart: unless-stopped
+  advbbs:
+    image: ghcr.io/zvx-echo6/advbbs:latest
+    container_name: advbbs
+    ports:
+      - "7681:7681"
+    volumes:
+      - ./data:/data
+    restart: unless-stopped
 
     # USB serial connection
     # Change this to match the address of your device
     # You should comment this out if you are connecting to the node over TCP.
     devices:
       - /dev/ttyUSB0:/dev/ttyUSB0
-      
+
     environment:
       - advBBS_CONFIG=/data/config.toml
       - TZ=${TZ:-UTC}


### PR DESCRIPTION
## Summary
- Fix YAML indentation so all service properties are properly nested under the `advbbs` service
- The previous commit added the service name but left properties at the wrong indentation level
- This caused `services.image must be a mapping` error when running `docker compose up`

## Test plan
- [ ] Run `docker compose config` to validate YAML syntax
- [ ] Run `docker compose up -d` to confirm container starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)